### PR TITLE
Update CI.yml

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,14 @@ jobs:
     runs-on: ubuntu-latest # 실행 환경 지정
 
     steps:
+      - name: Setup MySQL 
+        uses: samin/mysql-action@v1
+        with: 
+          character set server: 'utf8' 
+          mysql database: 'test'
+          mysql user: 'test'
+          mysql password: 'test'
+    
       - uses: actions/checkout@v2 # github action 버전 지정(major version)
 
       - name: Set up JDK 11 # JAVA 버전 지정


### PR DESCRIPTION
- `develop` 브랜치에 PR할 때 CI를 통과하지 못했습니다.
- mysql server를 시작하지 않아서 발생한 문제였습니다.
- 해당 로직을 CI.yml에 추가했습니다.