### PR TITLE
Fix: token mismatch

### DIFF
--- a/src/main/kotlin/waffle/team3/wafflestagram/global/oauth/service/OauthService.kt
+++ b/src/main/kotlin/waffle/team3/wafflestagram/global/oauth/service/OauthService.kt
@@ -73,7 +73,7 @@ class OauthService(
             builder.toUriString(),
             HttpMethod.GET
         )
-        if (response.statusCode == HttpStatus.OK) throw InvalidTokenException("Wrong validation")
+        if (response.statusCode != HttpStatus.OK) throw InvalidTokenException("Wrong validation")
         return objectMapper.readValue(response.body, HashMap::class.java)
     }
 
@@ -110,7 +110,7 @@ class OauthService(
 
         if (response.statusCode != HttpStatus.OK) throw InvalidTokenException("Wrong validation")
 
-        val userIdAndEmail = findUserIdAndEmail(accessToken)
+        val userIdAndEmail = findUserIdAndEmail(token)
             ?: throw UserDoesNotExistException("User with this email does not exist.")
         val email = userIdAndEmail["email"]
         return userRepository.findByEmail(email as String)


### PR DESCRIPTION
user의 email, id 등을 조회할 때 access token이 아닌 user access token이 들어가도록 바꿔서 오류 해결했습니다. 